### PR TITLE
fix(nodev6): socket.destroy() throws segmentation fault, end() is enough

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,6 @@ function enableDestroy(server) {
   server.destroy = function(cb) {
     server.close(cb);
     for (var key in connections)
-      connections[key].destroy();
+      connections[key].end();
   };
 }


### PR DESCRIPTION
Dunno why, but socket.destroy() throws segmentation fault here. .end() works well
